### PR TITLE
Drop unnecessary npm filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "module": "dist/index.es.js",
   "main": "dist/index.js",
   "engines": {
-    "node": ">=8.9.3",
-    "npm": "~5.5.1"
+    "node": ">=8.9.3"
   },
   "files": [
     "dist",


### PR DESCRIPTION
#5 hasn't bee published yet, but the `npm` field also breaks now:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'twas@2.1.1',
npm WARN EBADENGINE   required: { node: '~8.9.3', npm: '~5.5.1' },
npm WARN EBADENGINE   current: { node: 'v15.2.1', npm: '7.0.8' }
npm WARN EBADENGINE }
```

`npm` can be dropped