### PR TITLE
Drop failing Node 6 CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '6'
   - '8'
   - '10'
 after_script: "cat ./coverage/lcov.info | coveralls"


### PR DESCRIPTION
Node 6 is failing:

```
/home/travis/build/vutran/twas/node_modules/iltorb/index.js:134
  params = { ...params, size_hint: input.length };
             ^^^
SyntaxError: Unexpected token ...
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:549:28)
    at Object.Module._extensions..js (module.js:586:10)
    at Module.load (module.js:494:32)
    at tryModuleLoad (module.js:453:12)
    at Function.Module._load (module.js:445:3)
    at Module.require (module.js:504:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/travis/build/vutran/twas/node_modules/brotli-size/index.js:3:14)

```

And can be dropped since `package.json` specifies node >=8 anyway